### PR TITLE
Adds PHPUnit as a Dev Dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+test/coverage

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,8 @@
     "psr-0": {
       "Lootils\\Geo": "src/"
     }
+  },
+  "require-dev": {
+    "phpunit/phpunit": "~4.5"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,19 @@
+<phpunit>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>./test/Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+
+    <logging>
+        <log type="coverage-clover" target="./test/coverage/clover.xml" />
+        <log type="coverage-html" target="./test/coverage" />
+        <log type="coverage-text" target="php://stdout" />
+    </logging>
+</phpunit>

--- a/test/Tests/EarthTest.php
+++ b/test/Tests/EarthTest.php
@@ -6,9 +6,6 @@
 
 namespace Lootils\Geo;
 
-require_once 'PHPUnit/Autoload.php';
-require_once 'vendor/autoload.php';
-
 use \Lootils\Geo\Earth;
 
 class EarthTest extends \PHPUnit_Framework_TestCase {

--- a/test/Tests/LocationTest.php
+++ b/test/Tests/LocationTest.php
@@ -6,9 +6,6 @@
 
 namespace Lootils\Geo;
 
-require_once 'PHPUnit/Autoload.php';
-require_once 'vendor/autoload.php';
-
 use \Lootils\Geo\Location;
 use \Lootils\Geo\Exception;
 

--- a/test/Tests/VincentyTest.php
+++ b/test/Tests/VincentyTest.php
@@ -6,9 +6,6 @@
 
 namespace Lootils\Geo;
 
-require_once 'PHPUnit/Autoload.php';
-require_once 'vendor/autoload.php';
-
 use \Lootils\Geo\Location;
 use \Lootils\Geo\Geo;
 

--- a/test/Tests/YeeTest.php
+++ b/test/Tests/YeeTest.php
@@ -6,9 +6,6 @@
 
 namespace Lootils\Geo;
 
-require_once 'PHPUnit/Autoload.php';
-require_once 'vendor/autoload.php';
-
 use \Lootils\Geo\Location;
 
 class YeeTest extends \PHPUnit_Framework_TestCase {


### PR DESCRIPTION
As a developer who likes this library and wants to contribute, I was
surprised to find that phpunit was not installed and configured as a
project dependency.

Installs phpunit as a dev dependency using `composer require --dev
phpunit/phpunit`.

Adds a basic `phpunit.xml.dist` file for default phpunit configuration.

Remove unnecessary `require_once` on phpunit autoload and vendor autoload.
Composer autoloads phpunit. And newer versions of phpunit pick up the
vendor autoload automatically.

Ignores `test/coverage` which holds the generated clover and html reports.

Update .travis.yml file to run composer installed phpunit.

Now all a contributer need do is:

```
git clone <repo>
cd <clone_dir>
composer install
./vendor/bin/phpunit
```

I have `./vendor/bin` on my path, so I just run `phpunit` instead of
`./vendor/bin/phpunit`.

Happy TDD!